### PR TITLE
Generate metrics in RemoteWrite client, use generator function for labels

### DIFF
--- a/remote_write.go
+++ b/remote_write.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -135,7 +134,7 @@ func generate_series(total_series, batches, batch_size, batch int64) ([]Timeseri
 
 		series[i] = Timeseries{
 			labels,
-			[]Sample{{rand.Float64() * 100, timestamp}},
+			[]Sample{{float64(timestamp / 1000), timestamp}},
 		}
 	}
 

--- a/remote_write.go
+++ b/remote_write.go
@@ -101,7 +101,7 @@ func (r *RemoteWrite) XTimeseries(labels map[string]string, samples []Sample) *T
 func (c *Client) StoreGenerated(ctx context.Context, total_series, batches, batch_size, batch int64) (httpext.Response, error) {
 	ts, err := generate_series(total_series, batches, batch_size, batch)
 	if err != nil {
-		return nil, err
+		return *httpext.NewResponse(ctx), err
 	}
 	return c.Store(ctx, ts)
 }

--- a/remote_write.go
+++ b/remote_write.go
@@ -141,7 +141,7 @@ func generate_cardinality_labels(total_series, series_id int64) []Label {
 	labels := make([]Label, 0, exp)
 	for x := 1; int64(x) <= exp; x++ {
 		labels = append(labels, Label{
-			Name:  "cardinality_1e%d" + strconv.Itoa(x),
+			Name:  "cardinality_1e" + strconv.Itoa(x),
 			Value: strconv.Itoa(int(series_id / int64(math.Pow(10, float64(x))))),
 		})
 	}

--- a/remote_write.go
+++ b/remote_write.go
@@ -143,7 +143,7 @@ func generate_series(total_series, batches, batch_size, batch int64) ([]Timeseri
 
 func generate_cardinality_labels(total_series, series_id int64) []Label {
 	// exp is the greatest exponent of 10 that is less than total series.
-	exp := int64(math.Log10(2000))
+	exp := int64(math.Log10(float64(total_series)))
 	labels := make([]Label, 0, exp)
 	for x := 1; int64(x) <= exp; x++ {
 		labels = append(labels, Label{

--- a/remote_write.go
+++ b/remote_write.go
@@ -117,7 +117,7 @@ func generate_series(total_series, batches, batch_size, batch int64) ([]Timeseri
 		return nil, errors.New("total_series must divide evenly into batches of size batch_size")
 	}
 
-	series := make([]Timeseries, 0, batch_size)
+	series := make([]Timeseries, batch_size)
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	for i := int64(0); i < batch_size; i++ {
 		series_id := batch_size*(batch-1) + i

--- a/remote_write.go
+++ b/remote_write.go
@@ -126,6 +126,13 @@ func generate_series(total_series, batches, batch_size, batch int64) ([]Timeseri
 			Name:  "__name__",
 			Value: "k6_generated_metric_" + strconv.Itoa(int(series_id)),
 		})
+
+		// Required for querying in order to have unique series excluding the metric name.
+		labels = append(labels, Label{
+			Name:  "series_id",
+			Value: strconv.Itoa(int(series_id)),
+		})
+
 		series[i] = Timeseries{
 			labels,
 			[]Sample{{rand.Float64() * 100, timestamp}},


### PR DESCRIPTION
This is a performance optimization which allows the user to generate series inside the k6 extension, which is more efficient than passing the generated series from the javascript runtime into the extension.

To give the user control over which labels shall be associated with the generated series the method `StoreFromLabelGenerator` takes a generator function that returns the labels.