### PR TITLE
Streaming marshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ const template = {
     __name__: 'k6_generated_metric_${series_id/4}',    // Name of the series.
     series_id: '${series_id}',                         // Each value of this label will match 1 series.
     cardinality_1e1: '${series_id/10}',                // Each value of this label will match 10 series.
+    cardinality_2: '${series_id%2}',                   // Each value of this label will match 2 series.
 };
 
 write_client.storeFromTemplates(
@@ -129,15 +130,15 @@ write_client.storeFromTemplates(
 The above code could generate and send the following 3 samples, values are randomly chosen from the defined range:
 
 ```
-Metric:    k6_generated_metric_10{cardinality_1e1="4", series_id="42"},
+Metric:    k6_generated_metric_10{cardinality_1e1="4", cardinality_2="0", series_id="42"},
 Timestamp: 16432354331000
 Value:     193
 ---
-Metric:    k6_generated_metric_10{cardinality_1e1="4", series_id="43"},
+Metric:    k6_generated_metric_10{cardinality_1e1="4", cardinality_2="1", series_id="43"},
 Timestamp: 16432354331000
 Value:     121
 ---
-Metric:    k6_generated_metric_11{cardinality_1e1="4", series_id="44"},
+Metric:    k6_generated_metric_11{cardinality_1e1="4", cardinality_2="0", series_id="44"},
 Timestamp: 16432354331000
 Value:     142
 ```

--- a/bench_test.go
+++ b/bench_test.go
@@ -22,29 +22,33 @@ import (
 
 func BenchmarkCompileTemplatesSimple(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = compileTemplate("something ${series_id} else")
+		_, err := compileTemplate("something ${series_id} else")
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkCompileTemplatesComplex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = compileTemplate("something ${series_id/1000} else")
+		_, err := compileTemplate("something ${series_id/1000} else")
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkEvaluateTemplatesSimple(b *testing.B) {
-	t := compileTemplate("something ${series_id} else")
+	t, err := compileTemplate("something ${series_id} else")
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = t(i)
+		_ = t.ToString(i)
 	}
 }
 
 func BenchmarkEvaluateTemplatesComplex(b *testing.B) {
-	t := compileTemplate("something ${series_id/1000} else")
+	t, err := compileTemplate("something ${series_id/1000} else")
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = t(i)
+		_ = t.ToString(i)
 	}
 }
 
@@ -127,7 +131,8 @@ func BenchmarkGenerateFromTemplates(b *testing.B) {
 		r := rand.New(rand.NewSource(time.Now().Unix()))
 		for pb.Next() {
 			i++
-			_ = generateFromTemplates(r, i, i+10, int64(i), 0, 100000, benchmarkLabels)
+			_, err := generateFromTemplates(r, i, i+10, int64(i), 0, 100000, benchmarkLabels)
+			require.NoError(b, err)
 		}
 	})
 }
@@ -140,12 +145,13 @@ func BenchmarkGenerateFromTemplatesAndMarshal(b *testing.B) {
 		r := rand.New(rand.NewSource(time.Now().Unix()))
 		for pb.Next() {
 			i++
-			batch := generateFromTemplates(r, i, i+10, int64(i), 0, 100000, benchmarkLabels)
+			batch, err := generateFromTemplates(r, i, i+10, int64(i), 0, 100000, benchmarkLabels)
+			require.NoError(b, err)
 
 			req := prompb.WriteRequest{
 				Timeseries: batch,
 			}
-			_, err := proto.Marshal(&req)
+			_, err = proto.Marshal(&req)
 			require.NoError(b, err)
 		}
 	})

--- a/bench_test.go
+++ b/bench_test.go
@@ -3,10 +3,12 @@ package remotewrite
 import (
 	"context"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/oxtoacart/bpool"
@@ -122,9 +124,10 @@ func BenchmarkGenerateFromTemplates(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
+		r := rand.New(rand.NewSource(time.Now().Unix()))
 		for pb.Next() {
 			i++
-			_ = generateFromTemplates(i, i+10, int64(i), 0, 100000, benchmarkLabels)
+			_ = generateFromTemplates(r, i, i+10, int64(i), 0, 100000, benchmarkLabels)
 		}
 	})
 }
@@ -134,9 +137,10 @@ func BenchmarkGenerateFromTemplatesAndMarshal(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
+		r := rand.New(rand.NewSource(time.Now().Unix()))
 		for pb.Next() {
 			i++
-			batch := generateFromTemplates(i, i+10, int64(i), 0, 100000, benchmarkLabels)
+			batch := generateFromTemplates(r, i, i+10, int64(i), 0, 100000, benchmarkLabels)
 
 			req := prompb.WriteRequest{
 				Timeseries: batch,

--- a/bench_test.go
+++ b/bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkEvaluateTemplatesSimple(b *testing.B) {
 	t := compileTemplate("something ${series_id} else")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = t(1151234)
+		_ = t(i)
 	}
 }
 
@@ -44,7 +44,7 @@ func BenchmarkEvaluateTemplatesComplex(b *testing.B) {
 	t := compileTemplate("something ${series_id/1000} else")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = t(1151234)
+		_ = t(i)
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,22 @@
 package remotewrite
 
-import "testing"
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/oxtoacart/bpool"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/metrics"
+	"go.k6.io/k6/stats"
+)
 
 func BenchmarkCompileTemplatesSimple(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -28,4 +44,105 @@ func BenchmarkEvaluateTemplatesComplex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = t(1151234)
 	}
+}
+
+var benchmarkLabels = map[string]string{
+	"__name__":        "k6_generated_metric_${series_id/1000}",
+	"series_id":       "${series_id}",
+	"cardinality_1e1": "${series_id/10}",
+	"cardinality_1e2": "${series_id/100}",
+	"cardinality_1e3": "${series_id/1000}",
+	"cardinality_1e4": "${series_id/10000}",
+	"cardinality_1e5": "${series_id/100000}",
+	"cardinality_1e6": "${series_id/1000000}",
+	"cardinality_1e7": "${series_id/10000000}",
+	"cardinality_2":   "${series_id%2}",
+	"cardinality_50":  "${series_id%50}",
+}
+
+type testServer struct {
+	server *httptest.Server
+	vu     *modulestest.VU
+	count  *int64
+}
+
+func newTestServer(tb testing.TB) *testServer {
+	ts := &testServer{
+		count: new(int64),
+	}
+
+	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.WriteHeader(200)
+		atomic.AddInt64(ts.count, 1)
+	}))
+	ch := make(chan stats.SampleContainer)
+	tb.Cleanup(func() {
+		ts.server.Close()
+		close(ch) // this might need to be elsewhere
+	})
+	ts.vu = new(modulestest.VU)
+	ts.vu.StateField = new(lib.State)
+	ts.vu.CtxField = context.Background()
+	ts.vu.StateField.Tags = lib.NewTagMap(nil)
+	ts.vu.StateField.Transport = ts.server.Client().Transport
+	ts.vu.StateField.BPool = bpool.NewBufferPool(123)
+	ts.vu.StateField.Samples = ch
+	ts.vu.StateField.BuiltinMetrics = metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+
+	go func() {
+		for range ch {
+		}
+	}()
+	return ts
+}
+
+func BenchmarkStoreFromTemplates(b *testing.B) {
+	s := newTestServer(b)
+	c := &Client{
+		client: &http.Client{},
+		cfg: &Config{
+			Url:     s.server.URL,
+			Timeout: "100s",
+		},
+		vu: s.vu,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.StoreFromTemplates(i, i+10, int64(i), 0, 100000, benchmarkLabels)
+		require.NoError(b, err)
+	}
+	require.True(b, 1 <= *s.count) // this might need an atomic
+}
+
+func BenchmarkGenerateFromTemplates(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			_ = generateFromTemplates(i, i+10, int64(i), 0, 100000, benchmarkLabels)
+		}
+	})
+}
+
+func BenchmarkGenerateFromTemplatesAndMarshal(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			batch := generateFromTemplates(i, i+10, int64(i), 0, 100000, benchmarkLabels)
+
+			req := prompb.WriteRequest{
+				Timeseries: batch,
+			}
+			_, err := proto.Marshal(&req)
+			require.NoError(b, err)
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220110113543-261677941f3c
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.4
+	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/prometheus v1.8.2-0.20210621150501-ff58416a0b02
 	github.com/stretchr/testify v1.7.0
@@ -39,7 +40,6 @@ require (
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/xhit/go-str2duration/v2 v2.0.0
 	go.k6.io/k6 v0.36.0
+	google.golang.org/protobuf v1.26.0
 )
 
 require (
@@ -57,7 +58,6 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/guregu/null.v3 v3.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/remote_write.go
+++ b/remote_write.go
@@ -327,6 +327,18 @@ func compileTemplate(template string) func(int) string {
 		return func(seriesID int) string {
 			return template[:i] + strconv.Itoa(seriesID) + template[i+len("${series_id}"):]
 		}
+	case '%':
+		end := strings.Index(template[i:], "}")
+		if end == -1 {
+			return func(_ int) string { return template }
+		}
+		d, err := strconv.Atoi(template[i+len("${series_id%") : i+end])
+		if err != nil {
+			return func(_ int) string { return template }
+		}
+		return func(seriesID int) string {
+			return template[:i] + strconv.Itoa(seriesID%d) + template[i+end+1:]
+		}
 	case '/':
 		end := strings.Index(template[i:], "}")
 		if end == -1 {
@@ -336,7 +348,6 @@ func compileTemplate(template string) func(int) string {
 		if err != nil {
 			return func(_ int) string { return template }
 		}
-
 		return func(seriesID int) string {
 			return template[:i] + strconv.Itoa(seriesID/d) + template[i+end+1:]
 		}

--- a/remote_write.go
+++ b/remote_write.go
@@ -490,12 +490,11 @@ func (c *Client) StoreFromTemplates(
 	timestamp int64, minSeriesID, maxSeriesID int,
 	labelsTemplate map[string]string,
 ) (httpext.Response, error) {
-	r := rand.New(rand.NewSource(time.Now().Unix()))
-	ts, err := generateFromTemplates(r, minValue, maxValue, timestamp, minSeriesID, maxSeriesID, labelsTemplate)
+	template, err := compileLabelTemplates(labelsTemplate)
 	if err != nil {
-		return httpext.Response{}, err
+		return *httpext.NewResponse(), err
 	}
-	return c.store(ts)
+	return c.StoreFromPrecompiledTemplates(minValue, maxValue, timestamp, minSeriesID, maxSeriesID, template)
 }
 
 func (template *labelTemplates) writeFor(w *bytes.Buffer, value float64, seriesID int, timestamp int64) (err error) {

--- a/remote_write.go
+++ b/remote_write.go
@@ -2,6 +2,7 @@ package remotewrite
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"log"
 	"math"
@@ -23,6 +24,7 @@ import (
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/netext/httpext"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 // Register the extension on module initialization, available to
@@ -49,9 +51,10 @@ func (r *remoteWriteModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (r *RemoteWrite) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]interface{}{
-			"Client":     r.xclient,
-			"Sample":     r.sample,
-			"Timeseries": r.timeseries,
+			"Client":                   r.xclient,
+			"Sample":                   r.sample,
+			"Timeseries":               r.timeseries,
+			"precompileLabelTemplates": compileLabelTemplates,
 		},
 	}
 }
@@ -325,9 +328,16 @@ func compileTemplate(template string) (*labelGenerator, error) {
 	}
 	switch template[i+len("${series_id")] {
 	case '}':
-		return &labelGenerator{ToString: func(seriesID int) string {
-			return template[:i] + strconv.Itoa(seriesID) + template[i+len("${series_id}"):]
-		}}, nil
+		return &labelGenerator{
+			ToString: func(seriesID int) string {
+				return template[:i] + strconv.Itoa(seriesID) + template[i+len("${series_id}"):]
+			},
+			AppendByte: func(b []byte, seriesID int) []byte {
+				b = append(b, template[:i]...)
+				b = strconv.AppendInt(b, int64(seriesID), 10)
+				return append(b, template[i+len("${series_id}"):]...)
+			},
+		}, nil
 	case '%':
 		end := strings.Index(template[i:], "}")
 		if end == -1 {
@@ -337,14 +347,28 @@ func compileTemplate(template string) (*labelGenerator, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can't parse divisor of the module operator %w", err)
 		}
+
+		possibleValues := make([][]byte, d)
+		// TODO have an upper limit
+		for j := 0; j < d; j++ {
+			var b []byte
+			b = append(b, template[:i]...)
+			b = strconv.AppendInt(b, int64(j), 10)
+			possibleValues[j] = append(b, template[i+end+1:]...)
+		}
 		possibleValuesS := make([]string, d)
 		// TODO have an upper limit
 		for j := 0; j < d; j++ {
 			possibleValuesS[j] = template[:i] + strconv.Itoa((j)) + template[i+end+1:]
 		}
-		return &labelGenerator{ToString: func(seriesID int) string {
-			return possibleValuesS[seriesID%d]
-		}}, nil
+		return &labelGenerator{
+			ToString: func(seriesID int) string {
+				return possibleValuesS[seriesID%d]
+			},
+			AppendByte: func(b []byte, seriesID int) []byte {
+				return append(b, possibleValues[seriesID%d]...)
+			},
+		}, nil
 	case '/':
 		end := strings.Index(template[i:], "}")
 		if end == -1 {
@@ -357,6 +381,8 @@ func compileTemplate(template string) (*labelGenerator, error) {
 		var memoizeS string
 		var memoizeSValue int
 
+		var memoize []byte
+		var memoizeValue int64
 		return &labelGenerator{
 			ToString: func(seriesID int) string {
 				value := (seriesID / d)
@@ -366,18 +392,31 @@ func compileTemplate(template string) (*labelGenerator, error) {
 				}
 				return memoizeS
 			},
+			AppendByte: func(b []byte, seriesID int) []byte {
+				value := int64(seriesID / d)
+				if memoize == nil || value != memoizeValue {
+					memoizeValue = value
+					memoize = memoize[:0]
+					memoize = append(memoize, template[:i]...)
+					memoize = strconv.AppendInt(memoize, value, 10)
+					memoize = append(memoize, template[i+end+1:]...)
+				}
+				return append(b, memoize...)
+			},
 		}, nil
 	}
 	return nil, errors.New("unsupported template")
 }
 
 type labelGenerator struct {
-	ToString func(int) string
+	ToString   func(int) string
+	AppendByte func([]byte, int) []byte
 }
 
 func newIdentityLabelGenerator(t string) *labelGenerator {
 	return &labelGenerator{
-		ToString: func(int) string { return t },
+		ToString:   func(int) string { return t },
+		AppendByte: func(b []byte, _ int) []byte { return append(b, t...) },
 	}
 }
 
@@ -395,7 +434,7 @@ func generateFromTemplates(r *rand.Rand, minValue, maxValue int,
 	for seriesID := minSeriesID; seriesID < maxSeriesID; seriesID++ {
 		labels := make([]prompb.Label, len(labelsTemplate))
 		// TODO optimize
-		for i, template := range compiledTemplates {
+		for i, template := range compiledTemplates.compiledTemplates {
 			labels[i] = prompb.Label{Name: template.name, Value: template.generator.ToString(seriesID)}
 		}
 
@@ -413,12 +452,17 @@ func generateFromTemplates(r *rand.Rand, minValue, maxValue int,
 	return series, nil
 }
 
+// this is opaque on purpose so that it can't be done anything to from the js side
+type labelTemplates struct {
+	compiledTemplates []compiledTemplate
+	labelValue        []byte
+}
 type compiledTemplate struct {
 	name      string
 	generator *labelGenerator
 }
 
-func compileLabelTemplates(labelsTemplate map[string]string) ([]compiledTemplate, error) {
+func compileLabelTemplates(labelsTemplate map[string]string) (*labelTemplates, error) {
 	compiledTemplates := make([]compiledTemplate, len(labelsTemplate))
 	{
 		i := 0
@@ -435,7 +479,10 @@ func compileLabelTemplates(labelsTemplate map[string]string) ([]compiledTemplate
 	sort.Slice(compiledTemplates, func(i, j int) bool {
 		return compiledTemplates[i].name < compiledTemplates[j].name
 	})
-	return compiledTemplates, nil
+	return &labelTemplates{
+		compiledTemplates: compiledTemplates,
+		labelValue:        make([]byte, 128), // this is way more than necessary and it will grow if needed
+	}, nil
 }
 
 func (c *Client) StoreFromTemplates(
@@ -449,6 +496,98 @@ func (c *Client) StoreFromTemplates(
 		return httpext.Response{}, err
 	}
 	return c.store(ts)
+}
+
+func (template *labelTemplates) writeFor(w *bytes.Buffer, value float64, seriesID int, timestamp int64) (err error) {
+	labelValue := template.labelValue[:]
+	for _, template := range template.compiledTemplates {
+		labelValue = labelValue[:0]
+		w.WriteByte(0xa)
+		labelValue = protowire.AppendVarint(labelValue, uint64(len(template.name)))
+		n1 := len(labelValue)
+		labelValue = template.generator.AppendByte(labelValue, seriesID)
+		n2 := len(labelValue)
+		labelValue = protowire.AppendVarint(labelValue, uint64(n2-n1))
+		n3 := len(labelValue)
+
+		labelValue = protowire.AppendVarint(labelValue, uint64(n3+1+1+len(template.name)))
+		w.Write(labelValue[n3:])
+		w.WriteByte(0xa)
+		w.Write(labelValue[:n1])
+		w.WriteString(template.name)
+		w.WriteByte(0x12)
+		w.Write(labelValue[n2:n3])
+		w.Write(labelValue[n1:n2])
+	}
+
+	labelValue = labelValue[:10]
+	labelValue[0] = 0x9
+	binary.LittleEndian.PutUint64(labelValue[1:9], uint64(math.Float64bits(value)))
+	labelValue[9] = 0x10
+	labelValue = protowire.AppendVarint(labelValue, uint64(timestamp))
+
+	n := len(labelValue)
+	labelValue = labelValue[:n+1]
+	labelValue[n] = 0x12
+	labelValue = protowire.AppendVarint(labelValue, uint64(n))
+	w.Write(labelValue[n:])
+	w.Write(labelValue[:n])
+	template.labelValue = labelValue
+	return nil // TODO fix
+}
+
+func (c *Client) StoreFromPrecompiledTemplates(
+	minValue, maxValue int,
+	timestamp int64, minSeriesID, maxSeriesID int,
+	template *labelTemplates,
+) (httpext.Response, error) {
+	state := c.vu.State()
+	if state == nil {
+		return *httpext.NewResponse(), errors.New("State is nil")
+	}
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	buf := generateFromPrecompiledTemplates(r, minValue, maxValue, timestamp, minSeriesID, maxSeriesID, template)
+	b := buf.Bytes()
+	compressed := make([]byte, len(b)/9) // the general size is actually between 1/9 and 1/10th but this is closed enough
+	compressed = snappy.Encode(compressed, b)
+
+	res, err := c.send(state, compressed)
+	if err != nil {
+		return *httpext.NewResponse(), errors.Wrap(err, "remote-write request failed")
+	}
+	res.Request.Body = ""
+
+	return res, nil
+}
+
+func generateFromPrecompiledTemplates(
+	r *rand.Rand,
+	minValue, maxValue int,
+	timestamp int64, minSeriesID, maxSeriesID int,
+	template *labelTemplates,
+) *bytes.Buffer {
+	bigB := make([]byte, 1024)
+	buf := new(bytes.Buffer)
+	buf.Reset()
+
+	tsBuf := new(bytes.Buffer)
+	bigB[0] = 0xa
+	template.writeFor(tsBuf, valueBetween(r, minValue, maxValue), minSeriesID, timestamp)
+	bigB = protowire.AppendVarint(bigB[:1], uint64(tsBuf.Len()))
+	buf.Write(bigB)
+	tsBuf.WriteTo(buf)
+
+	buf.Grow((buf.Len() + 2) * (maxSeriesID - minSeriesID)) // heuristics to try to get big enough buffer in one go
+	for seriesID := minSeriesID + 1; seriesID < maxSeriesID; seriesID++ {
+		tsBuf.Reset()
+		bigB[0] = 0xa
+		template.writeFor(tsBuf, valueBetween(r, minValue, maxValue), seriesID, timestamp)
+		bigB = protowire.AppendVarint(bigB[:1], uint64(tsBuf.Len()))
+		buf.Write(bigB)
+		tsBuf.WriteTo(buf)
+	}
+
+	return buf
 }
 
 func valueBetween(r *rand.Rand, min, max int) float64 {

--- a/remote_write_test.go
+++ b/remote_write_test.go
@@ -1,8 +1,10 @@
 package remotewrite
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
@@ -110,7 +112,8 @@ func TestGenerateFromTemplates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateFromTemplates(tt.args.minValue, tt.args.maxValue, tt.args.timestamp, tt.args.minSeriesID, tt.args.maxSeriesID, tt.args.labelsTemplate)
+			r := rand.New(rand.NewSource(time.Now().Unix()))
+			got := generateFromTemplates(r, tt.args.minValue, tt.args.maxValue, tt.args.timestamp, tt.args.minSeriesID, tt.args.maxSeriesID, tt.args.labelsTemplate)
 			if len(got) != len(tt.want.series) {
 				t.Errorf("Differing length, want: %d, got: %d", len(tt.want.series), len(got))
 			}

--- a/remote_write_test.go
+++ b/remote_write_test.go
@@ -45,6 +45,8 @@ func TestGenerateFromTemplates(t *testing.T) {
 					"series_id":       "${series_id}",
 					"cardinality_1e1": "${series_id/10}",
 					"cardinality_1e3": "${series_id/1000}",
+					"cardinality_2":   "${series_id%2}",
+					"cardinality_10":  "${series_id%10}",
 				},
 			},
 			want: want{
@@ -54,40 +56,50 @@ func TestGenerateFromTemplates(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: "__name__", Value: "k6_generated_metric_50"},
+							{Name: "cardinality_10", Value: "0"},
 							{Name: "cardinality_1e1", Value: "5"},
 							{Name: "cardinality_1e3", Value: "0"},
+							{Name: "cardinality_2", Value: "0"},
 							{Name: "series_id", Value: "50"},
 						},
 						Samples: []prompb.Sample{{Timestamp: 123456789}},
 					}, {
 						Labels: []prompb.Label{
 							{Name: "__name__", Value: "k6_generated_metric_51"},
+							{Name: "cardinality_10", Value: "1"},
 							{Name: "cardinality_1e1", Value: "5"},
 							{Name: "cardinality_1e3", Value: "0"},
+							{Name: "cardinality_2", Value: "1"},
 							{Name: "series_id", Value: "51"},
 						},
 						Samples: []prompb.Sample{{Timestamp: 123456789}},
 					}, {
 						Labels: []prompb.Label{
 							{Name: "__name__", Value: "k6_generated_metric_52"},
+							{Name: "cardinality_10", Value: "2"},
 							{Name: "cardinality_1e1", Value: "5"},
 							{Name: "cardinality_1e3", Value: "0"},
+							{Name: "cardinality_2", Value: "0"},
 							{Name: "series_id", Value: "52"},
 						},
 						Samples: []prompb.Sample{{Timestamp: 123456789}},
 					}, {
 						Labels: []prompb.Label{
 							{Name: "__name__", Value: "k6_generated_metric_53"},
+							{Name: "cardinality_10", Value: "3"},
 							{Name: "cardinality_1e1", Value: "5"},
 							{Name: "cardinality_1e3", Value: "0"},
+							{Name: "cardinality_2", Value: "1"},
 							{Name: "series_id", Value: "53"},
 						},
 						Samples: []prompb.Sample{{Timestamp: 123456789}},
 					}, {
 						Labels: []prompb.Label{
 							{Name: "__name__", Value: "k6_generated_metric_54"},
+							{Name: "cardinality_10", Value: "4"},
 							{Name: "cardinality_1e1", Value: "5"},
 							{Name: "cardinality_1e3", Value: "0"},
+							{Name: "cardinality_2", Value: "0"},
 							{Name: "series_id", Value: "54"},
 						},
 						Samples: []prompb.Sample{{Timestamp: 123456789}},


### PR DESCRIPTION
Benchmarks results comparing first and last:
```
name                        old time/op    new time/op    delta
CompileTemplatesSimple-8       106ns ± 7%     984ns ±10%  +825.96%  (p=0.000 n=10+10)
CompileTemplatesComplex-8      181ns ± 8%    1415ns ± 6%  +681.53%  (p=0.000 n=10+10)
EvaluateTemplatesSimple-8      206ns ±10%      25ns ± 8%   -88.07%  (p=0.000 n=10+10)
EvaluateTemplatesComplex-8     186ns ± 7%       7ns ±10%   -96.24%  (p=0.000 n=10+10)
StoreFromTemplates-8           205ms ±10%     158ms ±10%   -23.00%  (p=0.000 n=10+9)

name                        old alloc/op   new alloc/op   delta
StoreFromTemplates-8           157MB ± 0%     117MB ± 0%   -25.35%  (p=0.000 n=9+10)

name                        old allocs/op  new allocs/op  delta
StoreFromTemplates-8            589k ± 0%        0k ± 1%   -99.95%  (p=0.000 n=10+10)
```

The really important part is that it no longer near close to 600k allocations but instead some three-digit number. This significantly reduces the CPU usage in the real world. 

If we compare
```
GenerateFromTemplatesAndMarshal-8  84.2ms ±15%
```
from the first commit - this is the part that has been heavily optimized and in the end replaced to
```
GenerateFromPrecompiledTemplates-8  27.4ms ±20%
```
(which does include the marshalling actually) you can see almost 4x improvement.

From some experiments it seems that a real world improvement will be in that vicinity if not better actually. 

This now also works for the "old" API. So we might think about not actually adding JS precompilation call and then using that precompilation if it's not needed :thinking: 

Additionally, template parsing errors are now imported back instead of being ignored and just using the template as the value.