### PR TITLE
Transfer code ownership to k6-extensions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @grafana/k6-ecosystem
+* @grafana/k6-extensions


### PR DESCRIPTION
This PR updates the code ownership in this repository, transferring it to the k6 extensions team.