### PR TITLE
Fix label ordering in examples to comply with Prometheus/Thanos

### DIFF
--- a/examples/benchtool.js
+++ b/examples/benchtool.js
@@ -19,15 +19,15 @@ export default function () {
             { "name": "__name__", "value": `metric_gauge_random_01` },
             { "name": "label_01", "value": `label_value_01_${randomIntBetween(1, 5)}` },
             { "name": "label_02", "value": `label_value_02_${randomIntBetween(1, 20)}` },
-            {"name": "replica", "value": __VU}
+            { "name": "replica", "value": __VU.toString() }
         ],
         "samples": generateRandomSamples(1000)
-    },{
+    }, {
         "labels": [
             { "name": "__name__", "value": `metric_gauge_zero_01` },
             { "name": "label_01", "value": `label_value_01_${randomIntBetween(1, 5)}` },
             { "name": "label_02", "value": `label_value_02_${randomIntBetween(1, 20)}` },
-            {"name": "replica", "value": __VU}
+            { "name": "replica", "value": __VU.toString() }
         ],
         "samples": generateEmptySamples(1000)
     }]);
@@ -37,7 +37,7 @@ export default function () {
     sleep(0.15);
 }
 
-function generateRandomSamples(number){
+function generateRandomSamples(number) {
     let samples = []
     for (let i = 0; i < number; i++) {
         samples.push({ "value": Math.random(), })
@@ -45,7 +45,7 @@ function generateRandomSamples(number){
     return samples
 }
 
-function generateEmptySamples(number){
+function generateEmptySamples(number) {
     let samples = []
     for (let i = 0; i < number; i++) {
         samples.push({ "value": 0, })

--- a/examples/full_write_example.js
+++ b/examples/full_write_example.js
@@ -4,20 +4,20 @@ import remote from 'k6/x/remotewrite';
 import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 const PROMETHEUS_TOKEN = __ENV.PROMETHEUS_TOKEN || fail("provide PROMETHEUS_TOKEN when strting k6");
-const PROMETHEUS_USERNAME =  __ENV.PROMETHEUS_USERNAME || fail("provide PROMETHEUS_USERNAME when strting k6");
+const PROMETHEUS_USERNAME = __ENV.PROMETHEUS_USERNAME || fail("provide PROMETHEUS_USERNAME when strting k6");
 const BASE_URL = 'prometheus-prod-10-prod-us-central-0.grafana.net';
 const RW_UNIQUE_METRICS = 50;
 const RW_SERIES_PER_METRIC = 20;
 
 const remote_write_url = `https://${PROMETHEUS_USERNAME}:${PROMETHEUS_TOKEN}@${BASE_URL}/api/prom/push`;
 
-let write_client = new remote.Client({url: remote_write_url});
+let write_client = new remote.Client({ url: remote_write_url });
 
 export let options = {
   thresholds: {
-    'remote_write_req_duration': [{threshold: 'p(95) < 1000', abortOnFail: false}],
-    'checks': [{threshold: 'rate==1', abortOnFail: true}],
-    'http_req_failed': [{threshold: 'rate==0.00', abortOnFail: true}],
+    'remote_write_req_duration': [{ threshold: 'p(95) < 1000', abortOnFail: false }],
+    'checks': [{ threshold: 'rate==1', abortOnFail: true }],
+    'http_req_failed': [{ threshold: 'rate==0.00', abortOnFail: true }],
   },
   scenarios: {
     writing_metrics: {
@@ -45,24 +45,24 @@ export function write_scenario() {
   }) || fail(JSON.stringify(res));
 }
 
-function generate_metrics(metric_name, numberOfSeries){
+function generate_metrics(metric_name, numberOfSeries) {
   let timestamp = Date.now();
-  
+
   console.log(`Writing batch of ${numberOfSeries} series. Metric name ${metric_name}`);
 
   let metrics = [];
 
   for (let series_id = 0; series_id < numberOfSeries; series_id++) {
     metrics.push({
-        "labels": [
-            { "name": "__name__", "value": metric_name },
-            { "name": "series_id", "value": series_id },
-            { "name": "service", "value": "bar" },
-            { "name": "host", "value": "test-host" },
-        ],
-        "samples": [
-            {  "value": randomIntBetween(1, 100), 'timestamp': timestamp },
-        ]
+      "labels": [
+        { "name": "__name__", "value": metric_name },
+        { "name": "host", "value": "test-host" },
+        { "name": "series_id", "value": series_id.toString() },
+        { "name": "service", "value": "bar" },
+      ],
+      "samples": [
+        { "value": randomIntBetween(1, 100), 'timestamp': timestamp },
+      ]
     })
   }
   return metrics


### PR DESCRIPTION
This PR fixes label ordering in example scripts to prevent 409 Conflict errors from Thanos.

## Problem

Prometheus/Thanos requires labels to be in lexicographic order (after `__name__`). The examples had labels in arbitrary order, causing Thanos to reject writes with 409 Conflict errors.

## Changes

- Sorted all labels alphabetically in examples

## Files Updated

- `examples/full_write_example.js`
- `examples/full_read_write_example.js`
- `examples/benchtool.js`

Fixes #39