### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/go:1": { "version": "1.24", "golangciLintVersion": "2.5.0" },
+    "ghcr.io/devcontainers/features/go:1": { "version": "1.25", "golangciLintVersion": "2.5.0" },
     "ghcr.io/guiyomh/features/goreleaser:0": { "version": "2.9.0" },
     "ghcr.io/michidk/devcontainers-features/bun:1": { "version": "1.2.12" },
     "ghcr.io/szkiba/devcontainer-features/gosec:1": { "version": "2.22.4" },
@@ -28,7 +28,7 @@
     "ghcr.io/szkiba/devcontainer-features/bats:1": { "version": "1.11.1" },
     "ghcr.io/szkiba/devcontainer-features/cdo:1": { "version": "0.1.2" },
     "ghcr.io/szkiba/devcontainer-features/mdcode:1": { "version": "0.2.0" },
-    "ghcr.io/grafana/devcontainer-features/xk6:1": { "version": "1.2.6" }
+    "ghcr.io/grafana/devcontainer-features/xk6:1": { "version": "1.4.1" }
   },
 
   "remoteEnv": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   release:
     name: Release
-    uses: grafana/xk6/.github/workflows/extension-release.yml@85233afdbdbff43ba927d474f1404edca0efd562 # v1.2.6
+    uses: grafana/xk6/.github/workflows/extension-release.yml@1556f094f3883e37ebff04b967fddac30681c466 # v1.4.1
     permissions:
       contents: write
     with:
-      go-version: "1.24.x"
+      go-version: "1.25.x"
       os: '["linux", "windows", "darwin"]'
       arch: '["amd64", "arm64"]'
-      k6-version: "v1.4.0"
-      xk6-version: "1.2.6"
+      k6-version: "v1.7.1"
+      xk6-version: "1.4.1"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,15 +12,15 @@ on:
 jobs:
   validate:
     name: Validate
-    uses: grafana/xk6/.github/workflows/extension-validate.yml@85233afdbdbff43ba927d474f1404edca0efd562 # v1.2.6
+    uses: grafana/xk6/.github/workflows/extension-validate.yml@1556f094f3883e37ebff04b967fddac30681c466 # v1.4.1
     permissions:
       pages: write
       id-token: write
       contents: read
     with:
-      go-version: "1.24.x"
-      go-versions: '["1.25.x","1.24.x"]'
+      go-version: "1.25.x"
+      go-versions: '["1.25.x"]'
       golangci-lint-version: "v2.5.0"
       platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      k6-versions: '["v1.4.0", "v1.0.0"]'
-      xk6-version: "1.2.6"
+      k6-versions: '["v1.7.1"]'
+      xk6-version: "1.4.1"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-client-prometheus-remote
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.4


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.