### PR TITLE
refactor: replace deprecated golang/protobuf/proto with v2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 toolchain go1.25.11
 
 require (
-	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v1.0.0
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	github.com/pkg/errors v0.9.1

--- a/remote_write.go
+++ b/remote_write.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Required for compatibility with prometheus prompb package
 	"github.com/golang/snappy"
 	"github.com/grafana/sobek"
 	"github.com/pkg/errors"
@@ -28,6 +27,8 @@ import (
 	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/lib/netext/httpext"
 	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/protoadapt"
 )
 
 var (
@@ -526,7 +527,7 @@ func (c *Client) store(batch []prompb.TimeSeries) (httpext.Response, error) {
 		Timeseries: batch,
 	}
 
-	data, err := proto.Marshal(&req)
+	data, err := proto.Marshal(protoadapt.MessageV2Of(&req))
 	if err != nil {
 		return *httpext.NewResponse(), errors.Wrap(err, "failed to marshal remote-write request")
 	}

--- a/remote_write_test.go
+++ b/remote_write_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // Required for compatibility with prometheus prompb package
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/protoadapt"
 )
 
 func TestEvaluateTemplate(t *testing.T) {
@@ -167,7 +168,7 @@ func TestGenerateFromTemplates(t *testing.T) {
 
 			req := new(prompb.WriteRequest)
 
-			require.NoError(t, proto.Unmarshal(buf.Bytes(), req))
+			require.NoError(t, proto.Unmarshal(buf.Bytes(), protoadapt.MessageV2Of(req)))
 			got := req.Timeseries
 
 			require.NoError(t, err)
@@ -218,7 +219,7 @@ func TestStreamEncoding(t *testing.T) {
 	minValue := 10
 	maxValue := 100000
 	// this is the upstream encoding. It is purposefully this "handwritten"
-	d, _ := proto.Marshal(&prompb.WriteRequest{
+	d, _ := proto.Marshal(protoadapt.MessageV2Of(&prompb.WriteRequest{
 		Timeseries: []prompb.TimeSeries{
 			{
 				Samples: []prompb.Sample{{
@@ -319,7 +320,7 @@ func TestStreamEncoding(t *testing.T) {
 				},
 			},
 		},
-	})
+	}))
 
 	// #nosec G404 -- Using math/rand in test code with deterministic seed for reproducible tests
 	r = rand.New(rand.NewSource(seed)) // reset


### PR DESCRIPTION
## Summary
Replaces the deprecated `github.com/golang/protobuf/proto` with the current `google.golang.org/protobuf/proto` for `Marshal`/`Unmarshal`.

## Details
- Prometheus `prompb` types are still gogo-generated and do not implement the v2 `protoreflect.ProtoMessage` interface, so they are bridged with `protoadapt.MessageV2Of`.
- Wire output is unchanged — verified by the existing byte-equality test (`require.Equal(t, d, b)`).
- `github.com/golang/protobuf` is no longer a dependency (removed from go.mod).

## Verification
```
go build ./...
go vet ./...
go test ./...   # pass
```