### PR TITLE
fix(examples): accept 2xx status for remote write checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ $ xk6 build --with github.com/grafana/xk6-client-prometheus-remote@latest
 
 For more build options and how to use xk6, check out the [xk6 documentation](https://github.com/grafana/xk6).
 
+## Validation
+
+To validate the extension end-to-end against a real Prometheus instance in Docker, run:
+
+```bash
+$ scripts/validate.sh
+```
+
+This builds a k6 binary with the extension, starts Prometheus with the remote write receiver enabled, remote-writes a metric, and confirms it is queryable. Useful for catching wire/protocol regressions after a Prometheus dependency bump. Requires `docker`, `xk6`, and `curl`.
+
 ## Contribute
 
 If you want to contribute or help with the development of **xk6-client-prometheus-remote**, start by reading [CONTRIBUTING.md](CONTRIBUTING.md). 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export default function () {
         ]
     }]);
     check(res, {
-        'is status 200': (r) => r.status === 200,
+        'is status 2xx': (r) => r.status >= 200 && r.status < 300,
     });
     sleep(1)
 }

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -21,7 +21,7 @@ export default function () {
         ]
     }]);
     check(res, {
-        'is status 200': (r) => r.status === 200,
+        'is status 2xx': (r) => r.status >= 200 && r.status < 300,
     });
     sleep(1)
 }

--- a/examples/benchtool.js
+++ b/examples/benchtool.js
@@ -32,7 +32,7 @@ export default function () {
         "samples": generateEmptySamples(1000)
     }]);
     check(res, {
-        'is status 200': (r) => r.status === 200,
+        'is status 2xx': (r) => r.status >= 200 && r.status < 300,
     });
     sleep(0.15);
 }

--- a/examples/full_read_write_example.js
+++ b/examples/full_read_write_example.js
@@ -69,7 +69,7 @@ export function write_scenario() {
   );
 
   check(res, {
-    'write worked': (r) => r.status === 200,
+    'write worked': (r) => r.status >= 200 && r.status < 300,
   }) || fail(JSON.stringify(res));
 }
 

--- a/examples/full_write_example.js
+++ b/examples/full_write_example.js
@@ -41,7 +41,7 @@ export function write_scenario() {
   );
 
   check(res, {
-    'write worked': (r) => r.status === 200,
+    'write worked': (r) => r.status >= 200 && r.status < 300,
   }) || fail(JSON.stringify(res));
 }
 

--- a/examples/two_scenarios.js
+++ b/examples/two_scenarios.js
@@ -36,7 +36,7 @@ export function increaseCounter() {
     },
     ]);
     check(res, {
-        'is status 200': (r) => r.status === 200,
+        'is status 2xx': (r) => r.status >= 200 && r.status < 300,
     });
     sleep(10);
 }
@@ -61,7 +61,7 @@ export function sendBatch() {
     }
     ]);
     check(res, {
-        'is status 200': (r) => r.status === 200,
+        'is status 2xx': (r) => r.status >= 200 && r.status < 300,
     });
     sleep(1)
 }

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,35 @@
+// End-to-end validation script for the xk6-client-prometheus-remote extension.
+// Writes a uniquely named metric to a Prometheus remote write endpoint and
+// asserts the store call succeeds. scripts/validate.sh then queries Prometheus
+// to confirm the data landed. Run via scripts/validate.sh, not directly.
+import remote from 'k6/x/remotewrite';
+import { check } from 'k6';
+
+const URL = __ENV.REMOTE_WRITE_URL || 'http://localhost:9090/api/v1/write';
+
+export const options = {
+    vus: 2,
+    iterations: 10,
+    thresholds: {
+        checks: ['rate==1.0'],
+    },
+};
+
+const client = new remote.Client({ url: URL });
+
+export default function () {
+    const res = client.store([
+        {
+            labels: [
+                { name: '__name__', value: 'xk6_validate_metric' },
+                { name: 'service', value: 'validation' },
+                { name: 'vu', value: `${__VU}` },
+            ],
+            samples: [{ value: __VU * 100 + __ITER, timestamp: Date.now() }],
+        },
+    ]);
+    check(res, {
+        // Prometheus remote write receiver returns 204 on success.
+        'store status 2xx': (r) => r.status >= 200 && r.status < 300,
+    });
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# End-to-end validation of the xk6-client-prometheus-remote extension against a
+# real Prometheus instance running in Docker.
+#
+# Steps:
+#   1. Build a k6 binary with the extension (via xk6).
+#   2. Start Prometheus with the remote write receiver enabled.
+#   3. Run scripts/validate.js to remote-write a uniquely named metric.
+#   4. Query Prometheus to confirm the metric landed.
+#
+# Useful after a Prometheus dependency bump to catch protocol/wire regressions.
+#
+# Usage: scripts/validate.sh
+#
+# Env overrides:
+#   PROM_IMAGE   Prometheus image           (default: prom/prometheus:latest)
+#   PROM_PORT    Host port for Prometheus   (default: 9090)
+#   K6_BIN       Existing k6 binary to use  (default: build one with xk6)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PROM_IMAGE="${PROM_IMAGE:-prom/prometheus:latest}"
+PROM_PORT="${PROM_PORT:-9090}"
+CONTAINER="xk6-prw-validate"
+METRIC="xk6_validate_metric"
+K6_BIN="${K6_BIN:-}"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; }
+
+cleanup() {
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    if [ -n "${BUILT_K6:-}" ]; then rm -f "$BUILT_K6"; fi
+}
+trap cleanup EXIT
+
+# 1. Build k6 with the extension (unless a binary was supplied).
+if [ -z "$K6_BIN" ]; then
+    log "Building k6 with the extension via xk6"
+    xk6 build --with "github.com/grafana/xk6-client-prometheus-remote=$REPO_ROOT" >/dev/null
+    K6_BIN="$REPO_ROOT/k6"
+    BUILT_K6="$K6_BIN"
+fi
+[ -x "$K6_BIN" ] || { err "k6 binary not found/executable: $K6_BIN"; exit 1; }
+
+# 2. Start Prometheus with the remote write receiver enabled.
+log "Starting Prometheus ($PROM_IMAGE) on port $PROM_PORT"
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" -p "$PROM_PORT:9090" "$PROM_IMAGE" \
+    --config.file=/etc/prometheus/prometheus.yml \
+    --web.enable-remote-write-receiver >/dev/null
+
+log "Waiting for Prometheus to become ready"
+for _ in $(seq 1 30); do
+    if curl -sf "http://localhost:$PROM_PORT/-/ready" >/dev/null 2>&1; then break; fi
+    sleep 1
+done
+curl -sf "http://localhost:$PROM_PORT/-/ready" >/dev/null || { err "Prometheus never became ready"; exit 1; }
+
+# 3. Remote-write a metric.
+log "Running k6 remote write script"
+REMOTE_WRITE_URL="http://localhost:$PROM_PORT/api/v1/write" \
+    "$K6_BIN" run "$REPO_ROOT/scripts/validate.js"
+
+# 4. Confirm the metric is queryable.
+log "Querying Prometheus for '$METRIC'"
+sleep 2
+RESULT="$(curl -sf "http://localhost:$PROM_PORT/api/v1/query?query=$METRIC")"
+COUNT="$(printf '%s' "$RESULT" | grep -o '"__name__"' | wc -l | tr -d ' ')"
+
+if [ "$COUNT" -gt 0 ]; then
+    log "SUCCESS: found $COUNT series for '$METRIC'"
+    printf '%s\n' "$RESULT"
+else
+    err "metric '$METRIC' not found in Prometheus"
+    printf '%s\n' "$RESULT" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Prometheus remote write receiver returns **204 No Content** on success, not 200. The example and README write checks asserted `r.status === 200`, which fails against a real Prometheus instance.

This PR:
- Widens the write-path checks in examples/README to accept any 2xx status (read/query checks stay `=== 200`, since the Prometheus query API returns 200).
- Adds a reusable docker-based end-to-end validation script.

## Context

Surfaced while validating the extension after the `prometheus v0.313.0` dependency upgrade (#98).

## Changes

**2xx write checks**
- `examples/basic.js`, `benchtool.js`, `two_scenarios.js`, `full_write_example.js`, `full_read_write_example.js` (write check only), `README.md` → `r.status >= 200 && r.status < 300`
- Query/read checks left unchanged (query API returns 200)
- `smoke.test.js` unchanged — only asserts symbol/constructor existence, no status check

**Validation harness**
- `scripts/validate.sh` — builds k6 with the extension, starts `prom/prometheus` with `--web.enable-remote-write-receiver`, remote-writes a metric, and confirms it is queryable. Self-cleans (container + built binary). Requires `docker`, `xk6`, `curl`.
- `scripts/validate.js` — the k6 remote write script it runs.
- README `Validation` section documenting it.

## Verification

`scripts/validate.sh` run end-to-end:
- store returned **204**, satisfying the new 2xx check (checks 100% pass)
- written series confirmed queryable via `/api/v1/query`